### PR TITLE
update API Gateway URL to support other AWS partitions

### DIFF
--- a/templates/hello-world/{{ cookiecutter.project_slug }}/template.yaml
+++ b/templates/hello-world/{{ cookiecutter.project_slug }}/template.yaml
@@ -32,7 +32,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use ${AWS::URLSuffix} to support other AWS partitions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
