### PR TITLE
fix: make the build target phony

### DIFF
--- a/templates/hello-world/{{ cookiecutter.project_slug }}/Makefile
+++ b/templates/hello-world/{{ cookiecutter.project_slug }}/Makefile
@@ -4,6 +4,7 @@ ARCH = aarch64-unknown-linux-gnu
 ARCH = x86_64-unknown-linux-gnu
 {%- endif %}
 
+.PHONY: build
 build:
 	cross build --release --target $(ARCH)
 	rm -rf ./build


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make the build target phony. As we uses the build folder for the Lambda function, running `make build` multiple time does nothing with `make` saying that the target is already up to date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
